### PR TITLE
Add cropping ability

### DIFF
--- a/crop.m
+++ b/crop.m
@@ -1,0 +1,14 @@
+% This function is used to select a region of interest (ROI) to be focused
+% on. Once an ROI is selected for one image, other images will be displayed
+% through the same ROI to aid comparison of images.
+%
+% Author: Elliot Tuck
+% Date: 20170816
+function crop()
+    % have user crop the image
+    [~, draw_ROI] = imcrop();
+    % set the ROI
+    setappdata(0, 'draw_ROI', draw_ROI);
+    % re-display the current image (which is now cropped)
+    ImgTestGui_ShowImage();
+end

--- a/load_noiseless_images_15_edited.m
+++ b/load_noiseless_images_15_edited.m
@@ -77,7 +77,8 @@ if ~background_checked
             rectangle('Position', sample_vector([3 1 4 2]), 'EdgeColor', ...
                 'w', 'LineWidth', 3, 'LineStyle', '-');
         end
-        if exist('draw_ROI', 'var')
+        if isappdata(0, 'draw_ROI')
+            draw_ROI = getappdata(0, 'draw_ROI');
             rectangle('Position', draw_ROI, 'LineWidth', 2, 'LineStyle', '--');
         end
         set(gca, 'CLim', [100, 500]);
@@ -131,10 +132,12 @@ if ~background_checked
     noise = getappdata(0, 'noise');
     original_noise = noise;
     setappdata(0, 'original_noise', original_noise);
-    if exist('draw_ROI', 'var')
-        noise = imcrop(noise, draw_ROI);
-        setappdata(0, 'noise', noise);
-    end
+%     if exist('draw_ROI', 'var')
+%     if isappdata(0, 'draw_ROI')
+%         draw_ROI = getappdata(0, 'draw_ROI');
+%         noise = imcrop(noise, draw_ROI);
+%         setappdata(0, 'noise', noise);
+%     end
     
     image_size = size(noise);
     vertsize = image_size(1);
@@ -165,9 +168,11 @@ if ~background_checked
             camera.zero_Gev_px = camera.zero_Gev_px + camera.default_ROI_Y - ...
                data.raw.images.(camera.name).ROI_Y(1);
         end
-        if exist('draw_ROI','var')
-            camera.zero_Gev_px = camera.zero_Gev_px - draw_ROI(2);
-        end
+%         if exist('draw_ROI','var')
+%         if isappdata(0, 'draw_ROI')
+%             draw_ROI = getappdata(0, 'draw_ROI');
+%             camera.zero_Gev_px = camera.zero_Gev_px - draw_ROI(2);
+%         end
         energy_calib_vector = get_energy_curve(camera.name, vertsize, ...
             camera.zero_Gev_px, resolution, theta0);
         setappdata(0, 'energy_calib_vector', energy_calib_vector);
@@ -229,12 +234,14 @@ if (isempty(this_image))
     end
 
     original_image = this_image;
-    if exist('draw_ROI', 'var')
-        % TODO: only do analysis on the ROI. i.e. cut the noise, cut the image to
-        % the ROI of the noise might not match the ROI of the image
-        this_image = imcrop(this_image, draw_ROI);
-        setappdata(0, 'this_image', this_image);
-    end
+%     if exist('draw_ROI', 'var')
+%     if isappdata(0, 'draw_ROI')
+%         draw_ROI = getappdata(0, 'draw_ROI');
+%         % TODO: only do analysis on the ROI. i.e. cut the noise, cut the image to
+%         % the ROI of the noise might not match the ROI of the image
+%         this_image = imcrop(this_image, draw_ROI);
+%         setappdata(0, 'this_image', this_image);
+%     end
 
     % scale background and subtract. These variables are determined in the
     % load_camera_config script

--- a/showImageLineout.m
+++ b/showImageLineout.m
@@ -54,30 +54,16 @@ lineout(i, j, :) = sum(this_image(:, box_region), 2);
 if show_image % fix for odd(1) or even(0)
     image_axis = subplot(1, 2, 1);
     if curr_image == 1
-        if exist('draw_ROI', 'var')
-            display_width = draw_ROI(3);
-            display_height = draw_ROI(4);
-            width_start = 1;
-            height_start = 1;
-            setappdata(0, 'height_start', height_start);
-            setappdata(0, 'width_start', width_start);
-            
-            if exist('axis_limits_lineout', 'var')
-                axis_limits_lineout(3) = draw_ROI(3);
-                axis_limits_lineout(4) = draw_ROI(4);
-            end
-        else
-            horizsize = getappdata(0, 'horizsize');
-            vertsize = getappdata(0, 'vertsize');
-            display_width = horizsize;
-            display_height = vertsize;
-            setappdata(0, 'display_width', display_width);
-            setappdata(0, 'display_height', display_height);
-            width_start = 1;
-            height_start = 1;
-            setappdata(0, 'height_start', height_start);
-            setappdata(0, 'width_start', width_start);
-        end
+        horizsize = getappdata(0, 'horizsize');
+        vertsize = getappdata(0, 'vertsize');
+        display_width = horizsize;
+        display_height = vertsize;
+        setappdata(0, 'display_width', display_width);
+        setappdata(0, 'display_height', display_height);
+        width_start = 1;
+        height_start = 1;
+        setappdata(0, 'height_start', height_start);
+        setappdata(0, 'width_start', width_start);
         
         % TODO: this will need to be set by me eventially!
         contained_p = get(handles.figureLineouts, 'position');
@@ -105,7 +91,24 @@ if show_image % fix for odd(1) or even(0)
 %         end
 
         set(gca, 'fontsize', 15);
-    end        
+    end
+    
+    if isappdata(0, 'draw_ROI')
+        draw_ROI = getappdata(0, 'draw_ROI');
+        display_width = draw_ROI(3);
+        display_height = draw_ROI(4);
+        setappdata(0, 'display_width', display_width);
+        setappdata(0, 'display_height', display_height);
+        width_start = draw_ROI(1);
+        height_start = draw_ROI(2);
+        setappdata(0, 'height_start', height_start);
+        setappdata(0, 'width_start', width_start);
+        if exist('axis_limits_lineout', 'var')
+            axis_limits_lineout(3) = draw_ROI(3);
+            axis_limits_lineout(4) = draw_ROI(4);
+        end
+    end
+    
     % make the original image if diagnostic is on, otherwise work
     % only with linearized (or otherwise processed?) image
     if log_color
@@ -140,12 +143,15 @@ if show_image % fix for odd(1) or even(0)
     end
 
     % writing and drawing on the image
-    height_start = getappdata(0, 'height_start');
-    display_height = getappdata(0, 'display_height');
-    display_width = getappdata(0, 'display_width');
     width_start = getappdata(0, 'width_start');
+    height_start = getappdata(0, 'height_start');
+    display_width = getappdata(0, 'display_width');
+    display_height = getappdata(0, 'display_height');
+    default_display_width = getappdata(0, 'default_display_width');
+    default_display_height = getappdata(0, 'default_display_height');
+    
     rectangles= [box_region(1) height_start box_region(end) - box_region(1) ...
-        display_height];                    
+        display_height];
     size_rectangles = size(rectangles);
     
     for k = 1:size_rectangles(1)
@@ -177,14 +183,16 @@ if show_image % fix for odd(1) or even(0)
         rectangle('position', DC_sample, 'linewidth', 2, 'linestyle', '--');
     end
     
-    text(.02 * display_width + width_start, .03 * display_height + ...
-        height_start, ['Shot: ' int2str(j) '/' int2str(num_images)], ...
-        'color', 'w', 'backgroundcolor', 'b');
-    
-    if exist('stack_text', 'var')
-        text(.02 * display_width + width_start, .1 * display_height + ...
-            height_start, stack_text{i}, 'color', 'w', 'backgroundcolor', ...
-            'blue');
+    % display shot number text
+    text(.02 * default_display_width + 1, .03 * default_display_height + 1, ...
+        ['Shot: ' int2str(j) '/' int2str(num_images)], 'color', 'w', ...
+        'backgroundcolor', 'b');
+
+    % if there is stack text to display, display it
+    if (isappdata(0, 'stack_text') && ~isempty(getappdata(0, 'stack_text')))
+        stack_text = getappdata(0, 'stack_text');
+        text(.02 * default_display_width + 1, .1 * default_display_height + ...
+            1, stack_text{i}, 'color', 'w', 'backgroundcolor', 'blue');
     end
     
     subplot(1, 2, 2)

--- a/uncrop.m
+++ b/uncrop.m
@@ -1,0 +1,24 @@
+% Uncrop the displayed images back to their original display widths and
+% heights.
+%
+% Author: Elliot Tuck
+% Date: 20170817
+function uncrop()
+    % reset display width and height values
+    default_display_width = getappdata(0, 'default_display_width');
+    default_display_height = getappdata(0, 'default_display_height');
+    setappdata(0, 'display_width', default_display_width);
+    setappdata(0, 'display_height', default_display_height);
+    % reset width and height start values
+    setappdata(0, 'width_start', 1);
+    setappdata(0, 'height_start', 1);
+    % remove draw_ROI
+    if isappdata(0, 'draw_ROI')
+        rmappdata(0, 'draw_ROI');
+    end
+    % re-display the current image (which is uncropped)
+    ImgTestGui_ShowImage();
+    % bring the main GUI to the front
+    figureImgTestGui = findobj('Tag', 'figureImgTestGui');
+    figure(figureImgTestGui);
+end


### PR DESCRIPTION
Add the ability to crop and uncrop an image, effectively setting a
region of interest (ROI) through which other images can be viewed.
The crop() and uncrop() functions can be called from the MATLAB
command window to achieve this functionality.

A known issue with this version is incorrectly adjusting energy tick
marks on the y-axis when cropping images from energy cameras.